### PR TITLE
 Rebuild for fmt 12.0 and spdlog 1.16 with fixes

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -2,8 +2,6 @@ c_stdlib:
 - sysroot
 c_stdlib_version:
 - '2.17'
-cdt_name:
-- conda
 channel_sources:
 - conda-forge
 channel_targets:
@@ -15,7 +13,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
-- '11.2'
+- '12.0'
 gmp:
 - '6'
 libboost_devel:

--- a/.ci_support/migrations/fmt12_spdlog116.yaml
+++ b/.ci_support/migrations/fmt12_spdlog116.yaml
@@ -1,0 +1,10 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for fmt 12.0 and spdlog 1.16
+  kind: version
+  migration_number: 1
+migrator_ts: 1760196591.995821
+fmt:
+- '12.0'
+spdlog:
+- '1.16'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '19'
 fmt:
-- '11.2'
+- '12.0'
 gmp:
 - '6'
 libboost_devel:

--- a/README.md
+++ b/README.md
@@ -139,12 +139,12 @@ it is possible to build and upload installable packages to the
 [conda-forge](https://anaconda.org/conda-forge) [anaconda.org](https://anaconda.org/)
 channel for Linux, Windows and OSX respectively.
 
-To manage the continuous integration and simplify feedstock maintenance
+To manage the continuous integration and simplify feedstock maintenance,
 [conda-smithy](https://github.com/conda-forge/conda-smithy) has been developed.
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
-For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
+For more information, please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========
@@ -171,7 +171,7 @@ merged, the recipe will be re-built and uploaded automatically to the
 everybody to install and use from the `conda-forge` channel.
 Note that all branches in the conda-forge/intervalxt-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
-on branches in forks and branches in the main repository should only be used to
+on branches in forks, and branches in the main repository should only be used to
 build distinct package versions.
 
 In order to produce a uniquely identifiable distribution:

--- a/recipe/fixfmt12.patch
+++ b/recipe/fixfmt12.patch
@@ -1,0 +1,15 @@
+diff --git a/libintervalxt/configure.ac b/libintervalxt/configure.ac
+index fe61b3e6..01023384 100644
+--- a/libintervalxt/configure.ac
++++ b/libintervalxt/configure.ac
+@@ -56,7 +56,9 @@ AX_CXX_CHECK_LIB([fmt], [fmt::v6::getpagesize()], , [
+     AX_CXX_CHECK_LIB([fmt], [fmt::v8::report_system_error(int code=0, const char* message=nullptr)], , [
+       AX_CXX_CHECK_LIB([fmt], [fmt::v9::report_system_error(int code=0, const char* message=nullptr)], , [
+         AX_CXX_CHECK_LIB([fmt], [fmt::v10::report_system_error(int code=0, const char* message=nullptr)], , [
+-          AX_CXX_CHECK_LIB([fmt], [fmt::v11::report_system_error(int code=0, const char* message=nullptr)], , [AC_MSG_ERROR([fmt library not found])], [-lfmt])
++          AX_CXX_CHECK_LIB([fmt], [fmt::v11::report_system_error(int code=0, const char* message=nullptr)], , [
++            AX_CXX_CHECK_LIB([fmt], [fmt::v12::report_system_error(int code=0, const char* message=nullptr)], , [AC_MSG_ERROR([fmt library not found])], [-lfmt])
++          ], [-lfmt])
+         ], [-lfmt])
+       ], [-lfmt])
+     ], [-lfmt])

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,8 @@ package:
 source:
   url: https://github.com/flatsurf/{{ name }}/releases/download/{{ version }}/{{ name }}-{{ version }}.tar.gz
   sha256: 2228f1f58bfe43ffc0f4f7d274aa7cf1d26c024980d498d4291d7f435123e745
+  patches:
+    - fixfmt12.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2228f1f58bfe43ffc0f4f7d274aa7cf1d26c024980d498d4291d7f435123e745
 
 build:
-  number: 0
+  number: 1
   # dependency libeantic is not available for Windows on conda-forge yet
   skip: true  # [win]
 


### PR DESCRIPTION
Backport https://github.com/flatsurf/intervalxt/pull/203 to avoid blocking the fmt 12.0 migration.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
